### PR TITLE
Add fullscreen option to graphics settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .classpath
 .settings
 .DS_Store
+/.vscode

--- a/src/main/java/lwjglwindow/LWJGLWindow.java
+++ b/src/main/java/lwjglwindow/LWJGLWindow.java
@@ -219,7 +219,10 @@ public class LWJGLWindow extends BaseWindow
 		else
 			GLFW.glfwSwapInterval(0);
 
+		setFullscreen(tanks.Game.game.fullscreen);
+
 		glfwShowWindow(window);
+
 	}
 
 	protected int createShader(String filename, int shaderType) throws Exception

--- a/src/main/java/tanks/Game.java
+++ b/src/main/java/tanks/Game.java
@@ -208,6 +208,11 @@ public class Game
 	public static String homedir;
 	public static Game game = new Game();
 
+	// Note: this is not used by the game to determine fullscreen status
+	// It is simply a value defined before
+	// Refer to Game.game.window.fullscreen for true fullscreen status
+	public boolean fullscreen = false;
+
 	private Game()
 	{
 		Game.game = this;

--- a/src/main/java/tanks/gui/screen/ScreenOptions.java
+++ b/src/main/java/tanks/gui/screen/ScreenOptions.java
@@ -219,6 +219,7 @@ public class ScreenOptions extends Screen
 			f.println("last_version=" + Game.lastVersion);
 			f.println("enable_extensions=" + Game.enableExtensions);
 			f.println("auto_load_extensions=" + Game.autoLoadExtensions);
+			f.println("fullscreen=" + Game.game.window.fullscreen);
 			f.stopWriting();
 		}
 		catch (FileNotFoundException e)
@@ -381,6 +382,9 @@ public class ScreenOptions extends Screen
 						break;
 					case "auto_load_extensions":
 						Game.autoLoadExtensions = Boolean.parseBoolean(optionLine[1]);
+						break;
+					case "fullscreen":
+						Game.game.fullscreen = Boolean.parseBoolean(optionLine[1]);
 						break;
 
 				}

--- a/src/main/java/tanks/gui/screen/ScreenOptionsGraphics.java
+++ b/src/main/java/tanks/gui/screen/ScreenOptionsGraphics.java
@@ -22,6 +22,8 @@ public class ScreenOptionsGraphics extends Screen
     public static final String birdsEyeText = "\u00A7000100200255bird's-eye";
     public static final String angledText = "\u00A7200100000255angled";
 
+    public static final String fullscreenText = "Fullscreen: ";
+
     public ScreenOptionsGraphics()
     {
         this.music = "menu_options.ogg";
@@ -97,6 +99,8 @@ public class ScreenOptionsGraphics extends Screen
             effects.text += "\u00A7200100000255" + (int) Math.round(Game.effectMultiplier * 100) + "%";
         else
             effects.text += ScreenOptions.onText;
+
+        fullscreen.text = fullscreenText + (Game.game.window.fullscreen ? ScreenOptions.onText : ScreenOptions.offText);
     }
 
     protected void update3dGroundButton()
@@ -263,7 +267,7 @@ public class ScreenOptionsGraphics extends Screen
     },
             "May fix flickering in thin edges---at the cost of performance------Requires restarting the game---to take effect");
 
-    Button back = new Button(this.centerX, this.centerY + this.objYSpace * 3.5, this.objWidth, this.objHeight, "Back", new Runnable()
+    Button back = new Button(this.centerX, this.centerY + this.objYSpace * 4.5, this.objWidth, this.objHeight, "Back", new Runnable()
     {
         @Override
         public void run()
@@ -281,6 +285,17 @@ public class ScreenOptionsGraphics extends Screen
             Game.screen = new ScreenOptionsShadows();
         }
     }, "Fancy lighting enables shadows and---allows for custom lighting in levels------Fancy lighting is quite graphically intense---and may significantly reduce framerate"
+    );
+
+    Button fullscreen = new Button(this.centerX, this.centerY + this.objYSpace * 3, this.objWidth, this.objHeight, "", new Runnable()
+    {
+        @Override
+        public void run()
+        { 
+            Game.game.window.setFullscreen(!Game.game.window.fullscreen);
+            fullscreen.text = fullscreenText + (Game.game.window.fullscreen ? ScreenOptions.onText : ScreenOptions.offText);
+        }
+    }, "Toggle fullscreen"
     );
 
     Button effects = new Button(this.centerX - this.objXSpace / 2, this.centerY + this.objYSpace * 1, this.objWidth, this.objHeight, "", new Runnable()
@@ -307,6 +322,8 @@ public class ScreenOptionsGraphics extends Screen
         altPerspective.update();
         shadows.update();
         antialiasing.update();
+        
+        fullscreen.update();
 
         back.update();
 
@@ -328,6 +345,10 @@ public class ScreenOptionsGraphics extends Screen
         this.drawDefaultBackground();
 
         back.draw();
+        
+        // Need to update fullscreen text in case user changes it via F11
+        fullscreen.text = fullscreenText + (Game.game.window.fullscreen ? ScreenOptions.onText : ScreenOptions.offText);
+        fullscreen.draw();
 
         antialiasing.draw();
         shadows.draw();

--- a/src/main/java/tanks/gui/screen/ScreenTitle.java
+++ b/src/main/java/tanks/gui/screen/ScreenTitle.java
@@ -37,6 +37,8 @@ public class ScreenTitle extends Screen implements ISeparateBackgroundScreen
 
 				Game.game.window.windowHandler.onWindowClose();
 
+				ScreenOptions.saveOptions(Game.homedir);
+
 				System.exit(0);
 			}
 		}


### PR DESCRIPTION
# Changes

- Now on game exit, settings are saved to `homedir`\\`optionsPath`\options.txt
- `Fullscreen` button added to graphics settings page
- F11 & F10 functionality still intact
- \\.vscode\ to gitignore (for vscode users 😄)