### PR TITLE
Give extensions the ability to register update/draw methods of their own.

### DIFF
--- a/src/main/java/tanks/Game.java
+++ b/src/main/java/tanks/Game.java
@@ -68,6 +68,9 @@ public class Game
 	public static final SynchronizedList<INetworkEvent> eventsOut = new SynchronizedList<INetworkEvent>();
 	public static final SynchronizedList<INetworkEvent> eventsIn = new SynchronizedList<INetworkEvent>();
 
+	public static final ArrayList<Runnable> updateMethods = new ArrayList<Runnable>(); // Used to allow extensions to have a method called on every frame
+	public static final ArrayList<Runnable> drawMethods = new ArrayList<Runnable>(); // Same as above, but for drawing. These methods will get called after all the other draw calls, which could be undesirable, but it is less confusing.
+
 	public static Team playerTeam = new Team("ally");
 	public static Team enemyTeam = new Team("enemy");
 
@@ -347,6 +350,38 @@ public class Game
 	public static void registerItem(Class<? extends Item> item, String name, String image)
 	{
 		new RegistryItem.ItemEntry(Game.registryItem, item, name, image);
+	}
+
+	/**
+	 * Register a method to be called after every game tick.
+	 * Each tick may not be consistent. For timers and other
+	 * features that require knowing actual time elapsed,
+	 * see <code>Panel.frameFrequency</code>.
+	 *
+ 	 * @param method a method to be called after each game tick
+	 * @see Panel#frameFrequency
+	 */
+	public static void registerUpdateMethod(Runnable method) {
+		Game.updateMethods.add(method);
+	}
+
+	/**
+	 * Register a method to be called after every frame.
+	 * You can draw your own UI elements in your method.
+	 * Framerate may not be consistent. For frame
+	 * independent animations, the progress should be
+	 * updated using a method registered using
+	 * <code>Game.registerUpdateMethod</code>.
+	 * <p>
+	 * You should not do any processing in the registered
+	 * method. Instead, do processing in methods registered
+	 * in <code>Game.registerUpdateMethod</code>.
+	 *
+	 * @param method a method to be called after each frame
+	 * @see Game#registerUpdateMethod(Runnable)
+	 */
+	public static void registerDrawMethod(Runnable method) {
+		Game.drawMethods.add(method);
 	}
 
 	public static void initScript()

--- a/src/main/java/tanks/Game.java
+++ b/src/main/java/tanks/Game.java
@@ -68,9 +68,6 @@ public class Game
 	public static final SynchronizedList<INetworkEvent> eventsOut = new SynchronizedList<INetworkEvent>();
 	public static final SynchronizedList<INetworkEvent> eventsIn = new SynchronizedList<INetworkEvent>();
 
-	public static final ArrayList<Runnable> updateMethods = new ArrayList<Runnable>(); // Used to allow extensions to have a method called on every frame
-	public static final ArrayList<Runnable> drawMethods = new ArrayList<Runnable>(); // Same as above, but for drawing. These methods will get called after all the other draw calls, which could be undesirable, but it is less confusing.
-
 	public static Team playerTeam = new Team("ally");
 	public static Team enemyTeam = new Team("enemy");
 
@@ -350,38 +347,6 @@ public class Game
 	public static void registerItem(Class<? extends Item> item, String name, String image)
 	{
 		new RegistryItem.ItemEntry(Game.registryItem, item, name, image);
-	}
-
-	/**
-	 * Register a method to be called after every game tick.
-	 * Each tick may not be consistent. For timers and other
-	 * features that require knowing actual time elapsed,
-	 * see <code>Panel.frameFrequency</code>.
-	 *
- 	 * @param method a method to be called after each game tick
-	 * @see Panel#frameFrequency
-	 */
-	public static void registerUpdateMethod(Runnable method) {
-		Game.updateMethods.add(method);
-	}
-
-	/**
-	 * Register a method to be called after every frame.
-	 * You can draw your own UI elements in your method.
-	 * Framerate may not be consistent. For frame
-	 * independent animations, the progress should be
-	 * updated using a method registered using
-	 * <code>Game.registerUpdateMethod</code>.
-	 * <p>
-	 * You should not do any processing in the registered
-	 * method. Instead, do processing in methods registered
-	 * in <code>Game.registerUpdateMethod</code>.
-	 *
-	 * @param method a method to be called after each frame
-	 * @see Game#registerUpdateMethod(Runnable)
-	 */
-	public static void registerDrawMethod(Runnable method) {
-		Game.drawMethods.add(method);
 	}
 
 	public static void initScript()

--- a/src/main/java/tanks/GameDrawer.java
+++ b/src/main/java/tanks/GameDrawer.java
@@ -1,6 +1,7 @@
 package tanks;
 
 import basewindow.IDrawer;
+import tanks.extension.Extension;
 
 public class GameDrawer implements IDrawer
 {
@@ -9,7 +10,23 @@ public class GameDrawer implements IDrawer
 	{
 		try
 		{
+			if (Game.enableExtensions) {
+				for (int i = 0; i < Game.extensionRegistry.extensions.size(); i++) {
+					Extension e = Game.extensionRegistry.extensions.get(i);
+
+					e.preDraw();
+				}
+			}
+
 			Panel.panel.draw();
+
+			if (Game.enableExtensions) {
+				for (int i = 0; i < Game.extensionRegistry.extensions.size(); i++) {
+					Extension e = Game.extensionRegistry.extensions.get(i);
+
+					e.draw();
+				}
+			}
 		}
 		catch (Throwable e)
 		{

--- a/src/main/java/tanks/GameUpdater.java
+++ b/src/main/java/tanks/GameUpdater.java
@@ -1,6 +1,7 @@
 package tanks;
 
 import basewindow.IUpdater;
+import tanks.extension.Extension;
 
 public class GameUpdater implements IUpdater
 {
@@ -9,7 +10,23 @@ public class GameUpdater implements IUpdater
 	{
 		try
 		{
+			if (Game.enableExtensions) {
+				for (int i = 0; i < Game.extensionRegistry.extensions.size(); i++) {
+					Extension e = Game.extensionRegistry.extensions.get(i);
+
+					e.preUpdate();
+				}
+			}
+
 			Panel.panel.update();
+
+			if (Game.enableExtensions) {
+				for (int i = 0; i < Game.extensionRegistry.extensions.size(); i++) {
+					Extension e = Game.extensionRegistry.extensions.get(i);
+
+					e.update();
+				}
+			}
 		}
 		catch (Throwable e)
 		{

--- a/src/main/java/tanks/extension/Extension.java
+++ b/src/main/java/tanks/extension/Extension.java
@@ -2,6 +2,7 @@ package tanks.extension;
 
 import basewindow.BaseFile;
 import tanks.Game;
+import tanks.IDrawable;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -9,7 +10,7 @@ import java.util.ArrayList;
 import java.util.Scanner;
 import java.util.jar.JarFile;
 
-public class Extension
+public class Extension implements IDrawable
 {
     public final String name;
     public JarFile jarFile;
@@ -22,6 +23,26 @@ public class Extension
     // Register things like tanks, obstacles, items, or network events here
     public void setUp()
     {
+
+    }
+
+    // Called before every tick. Perform tasks that need to run before the vanilla update() is called. Can be left blank.
+    public void preUpdate() {
+
+    }
+
+    // Called before every frame. Draw items that appear beneath everything else or configure draw state. Can be left blank.
+    public void preDraw() {
+
+    }
+
+    // Called after every tick. Perform tasks that need processing but aren't tied to a specific tank/item/bullet here. Can be left blank.
+    public void update() {
+
+    }
+
+    // Called after every frame. Draw UI elements, etc. here. Can be left blank.
+    public void draw() {
 
     }
 


### PR DESCRIPTION
Extensions can now have `update` and `draw` methods, which run *after* the original draw and update methods. Code that needs to be run before the originals can be placed in `preUpdate` and `preDraw`.

This makes extensions a lot more powerful, since the main limitation currently is the inability to run code outside specific tanks/bullets/mines.