### PR TITLE
Downgrade LWJGL to 3.3.3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,10 +12,12 @@ fun get_hash(): String {
         ?.trim() ?: ""
 }
 
-val lwjglVersion = "3.3.4"
+val lwjglVersion = "3.3.3"
 val lwjglNatives = listOf(
-    "natives-freebsd",
-    "natives-linux-arm32", "natives-linux-arm64", "natives-linux-ppc64le", "natives-linux-riscv64", "natives-linux",
+    //"natives-freebsd",
+    "natives-linux-arm32", "natives-linux-arm64", 
+	//"natives-linux-ppc64le", "natives-linux-riscv64", 
+	"natives-linux",
     "natives-macos", "natives-macos-arm64",
     "natives-windows-x86", "natives-windows", "natives-windows-arm64",
 )


### PR DESCRIPTION
Dropped support for Linux PPC, Linux RISCV, FreeBSD due to bug in newer versions of LWJGL.
These platforms will be re-added to the main build as soon as newer versions of LWJGL improve compatability with existing Linux, Windows, and OSX platforms.