### PR TITLE
Fix building in a non-git repo

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ fun get_hash(): String {
         .inputStream
         .bufferedReader()
         .readLine()
-        ?.trim() ?: ""
+        ?.trim() ?: "00000000"
 }
 
 val lwjglVersion = "3.3.3"


### PR DESCRIPTION
- No longer crashes when the repository is not a git repo or if git is not installed on the system
- Provides a build hash of all 0s to allow easy identification during bug reports