### PR TITLE
Tankson.compatibility

### DIFF
--- a/src/main/java/tanks/Game.java
+++ b/src/main/java/tanks/Game.java
@@ -518,6 +518,7 @@ public class Game
 		Drawing.initialize();
 		Panel.initialize();
 		Game.exitToTitle();
+		tanks.tankson.Compatability.init();
 
 		Hotbar.toggle = new Button(Drawing.drawing.interfaceSizeX / 2, Drawing.drawing.interfaceSizeY - 20, 150, 40, "", () -> Game.player.hotbar.persistent = !Game.player.hotbar.persistent);
 

--- a/src/main/java/tanks/Game.java
+++ b/src/main/java/tanks/Game.java
@@ -34,6 +34,7 @@ import tanks.rendering.ShaderGroundIntro;
 import tanks.rendering.ShaderGroundOutOfBounds;
 import tanks.rendering.ShaderTracks;
 import tanks.tank.*;
+import tanks.tankson.Compatibility;
 
 import java.io.*;
 import java.util.*;
@@ -518,7 +519,7 @@ public class Game
 		Drawing.initialize();
 		Panel.initialize();
 		Game.exitToTitle();
-		tanks.tankson.Compatability.init();
+		Compatibility.init();
 
 		Hotbar.toggle = new Button(Drawing.drawing.interfaceSizeX / 2, Drawing.drawing.interfaceSizeY - 20, 150, 40, "", () -> Game.player.hotbar.persistent = !Game.player.hotbar.persistent);
 

--- a/src/main/java/tanks/tankson/Compatability.java
+++ b/src/main/java/tanks/tankson/Compatability.java
@@ -1,0 +1,38 @@
+package tanks.tankson;
+
+import tanks.tank.Explosion;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+public class Compatability {
+    public static final HashMap<String, Function<Object, Object>> compatability_table = new HashMap<>();
+    public static final HashMap<String, String> field_table = new HashMap<>();
+
+    public static void init() {
+        compatability_table.put("explode_on_destroy", Compatability::updateExplosion);
+    }
+
+    public static Object convert(Field f, Object v) {
+        return compatability_table.get(Serializer.getid(f)).apply(v);
+    }
+
+    public static String convert(String f) {
+        return field_table.get(f);
+    }
+
+    // Explosions 1.6.b -> 1.6.c
+    public static Object updateExplosion(Object o) {
+        if (o instanceof Boolean) {
+            if ((Boolean) o) {
+                return new Explosion();
+            } else {
+                return null;
+            }
+        } else {
+            throw new RuntimeException("Update Explosions from 1.6.b --> 1.6.c");
+        }
+    }
+}

--- a/src/main/java/tanks/tankson/Compatibility.java
+++ b/src/main/java/tanks/tankson/Compatibility.java
@@ -4,19 +4,18 @@ import tanks.tank.Explosion;
 
 import java.lang.reflect.Field;
 import java.util.HashMap;
-import java.util.Map;
 import java.util.function.Function;
 
-public class Compatability {
-    public static final HashMap<String, Function<Object, Object>> compatability_table = new HashMap<>();
+public class Compatibility {
+    public static final HashMap<String, Function<Object, Object>> compatibility_table = new HashMap<>();
     public static final HashMap<String, String> field_table = new HashMap<>();
 
     public static void init() {
-        compatability_table.put("explode_on_destroy", Compatability::updateExplosion);
+        compatibility_table.put("explode_on_destroy", Compatibility::updateExplosion);
     }
 
     public static Object convert(Field f, Object v) {
-        return compatability_table.get(Serializer.getid(f)).apply(v);
+        return compatibility_table.get(Serializer.getid(f)).apply(v);
     }
 
     public static String convert(String f) {

--- a/src/main/java/tanks/tankson/Serializer.java
+++ b/src/main/java/tanks/tankson/Serializer.java
@@ -3,12 +3,9 @@ package tanks.tankson;
 import tanks.Game;
 import tanks.bullet.Bullet;
 import tanks.item.Item;
-import tanks.item.ItemBullet;
-import tanks.item.ItemEmpty;
 import tanks.tank.*;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Array;
 import java.lang.reflect.Field;
 import java.util.*;
 
@@ -242,17 +239,25 @@ public final class Serializer
             default:
                 throw new RuntimeException("Bad object type: " + (String) m.get("obj_type"));
         }
+
+        Set<String> processed = new HashSet<>();
+
         for (Field f : o.getClass().getFields())
         {
             if (f.isAnnotationPresent(Property.class) && m.containsKey(getid(f)))
             {
+                processed.add(getid(f));
                 try
                 {
                     Object o2 = f.get(o);
                     if (isTanksONable(f))
                     {
                         Object o3 = m.get(getid(f));
-                        f.set(o, parseObject((Map) o3));
+                        try {
+                            f.set(o, parseObject((Map<String, Object>) o3));
+                        } catch (ClassCastException e) {
+                            f.set(o, Compatability.convert(f, o3));
+                        }
                     }
                     else if (o2 instanceof ArrayList)
                     {
@@ -284,10 +289,23 @@ public final class Serializer
                 }
                 catch (Exception e)
                 {
+                    System.out.println(getid(f));
                     throw new RuntimeException(e);
                 }
             }
         }
+
+        Set<String> unused = m.keySet();
+        unused.removeAll(processed);
+        for (String k : unused) {
+            try {
+                o.getClass().getField(Compatability.convert(k)).set(o, m.get(k));
+            } catch (NoSuchFieldException | NullPointerException | IllegalAccessException e) {
+                System.out.println("Unconvertable field found!");
+            }
+        }
+
+
         return o;
     }
 

--- a/src/main/java/tanks/tankson/Serializer.java
+++ b/src/main/java/tanks/tankson/Serializer.java
@@ -300,6 +300,13 @@ public final class Serializer
         for (String k : unused) {
             try {
                 o.getClass().getField(Compatability.convert(k)).set(o, m.get(k));
+            } catch (ClassCastException e) {
+                try {
+                    Field f = o.getClass().getField(Compatability.convert(k));
+                    f.set(o, Compatability.convert(f, m.get(k)));
+                } catch (NoSuchFieldException | IllegalAccessException f) {
+                    throw new RuntimeException(f);
+                }
             } catch (NoSuchFieldException | NullPointerException | IllegalAccessException e) {
                 System.out.println("Unconvertable field found!");
             }

--- a/src/main/java/tanks/tankson/Serializer.java
+++ b/src/main/java/tanks/tankson/Serializer.java
@@ -256,7 +256,7 @@ public final class Serializer
                         try {
                             f.set(o, parseObject((Map<String, Object>) o3));
                         } catch (ClassCastException e) {
-                            f.set(o, Compatability.convert(f, o3));
+                            f.set(o, Compatibility.convert(f, o3));
                         }
                     }
                     else if (o2 instanceof ArrayList)
@@ -299,13 +299,14 @@ public final class Serializer
         unused.removeAll(processed);
         for (String k : unused) {
             try {
-                o.getClass().getField(Compatability.convert(k)).set(o, m.get(k));
+                o.getClass().getField(Compatibility.convert(k)).set(o, m.get(k));
             } catch (ClassCastException e) {
                 try {
-                    Field f = o.getClass().getField(Compatability.convert(k));
-                    f.set(o, Compatability.convert(f, m.get(k)));
+                    Field f = o.getClass().getField(Compatibility.convert(k));
+                    f.set(o, Compatibility.convert(f, m.get(k)));
                 } catch (NoSuchFieldException | IllegalAccessException f) {
                     throw new RuntimeException(f);
+                    System.out.println("Random Change!");
                 }
             } catch (NoSuchFieldException | NullPointerException | IllegalAccessException e) {
                 System.out.println("Unconvertable field found!");

--- a/src/main/java/tanks/tankson/Serializer.java
+++ b/src/main/java/tanks/tankson/Serializer.java
@@ -306,7 +306,6 @@ public final class Serializer
                     f.set(o, Compatibility.convert(f, m.get(k)));
                 } catch (NoSuchFieldException | IllegalAccessException f) {
                     throw new RuntimeException(f);
-                    System.out.println("Random Change!");
                 }
             } catch (NoSuchFieldException | NullPointerException | IllegalAccessException e) {
                 System.out.println("Unconvertable field found!");


### PR DESCRIPTION
Adds a compatibility layer to allow for non-tanksonables to become tanksonables later and allows for renaming of fields.