### PR TITLE
Chunk loading system 3: terrain renderer optimizations

### DIFF
--- a/src/main/java/lwjglwindow/ShaderUtil.java
+++ b/src/main/java/lwjglwindow/ShaderUtil.java
@@ -6,7 +6,6 @@ import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL15;
 import org.lwjgl.opengl.GL20;
 
-import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 
@@ -291,10 +290,10 @@ public class ShaderUtil extends BaseShaderUtil
         GL11.glDisableClientState(GL_VERTEX_ARRAY);
         GL11.glDisableClientState(GL_COLOR_ARRAY);
 
-        for (int i: this.enabledAttributes)
-        {
-            GL20.glDisableVertexAttribArray(i);
-        }
+        ArrayList<Integer> attributes = this.enabledAttributes;
+        //noinspection ForLoopReplaceableByForEach
+        for (int i = 0, attributesSize = attributes.size(); i < attributesSize; i++)
+            glDisableVertexAttribArray(attributes.get(i));
 
         this.enabledAttributes.clear();
     }

--- a/src/main/java/lwjglwindow/VBOStaticBatchRenderer.java
+++ b/src/main/java/lwjglwindow/VBOStaticBatchRenderer.java
@@ -167,9 +167,7 @@ public class VBOStaticBatchRenderer extends BaseShapeBatchRenderer
         {
             AttributeProperty prop = attributeProperties.get(i);
             for (float f : prop.floatArray)
-            {
                 prop.buffer.put(f);
-            }
         }
     }
 

--- a/src/main/java/lwjglwindow/VBOStaticBatchRenderer.java
+++ b/src/main/java/lwjglwindow/VBOStaticBatchRenderer.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 
 import static org.lwjgl.opengl.GL11.*;
 
+@SuppressWarnings("ForLoopReplaceableByForEach")
 public class VBOStaticBatchRenderer extends BaseShapeBatchRenderer
 {
     // Property class for parallel arrays

--- a/src/main/java/tanks/rendering/StaticTerrainRenderer.java
+++ b/src/main/java/tanks/rendering/StaticTerrainRenderer.java
@@ -3,6 +3,7 @@ package tanks.rendering;
 import basewindow.BaseShapeBatchRenderer;
 import basewindow.IBatchRenderableObject;
 import basewindow.ShaderGroup;
+import tanks.Chunk;
 import tanks.Drawing;
 import tanks.Game;
 import tanks.gui.screen.ILevelPreviewScreen;
@@ -60,8 +61,8 @@ public class StaticTerrainRenderer extends TerrainRenderer
 
         if (o instanceof Obstacle)
             sg = ((Obstacle) o).renderer;
-        else if (o instanceof RendererTile && ((RendererTile) o).obstacleAbove != null)
-            sg = ((RendererTile) o).obstacleAbove.tileRenderer;
+        else if (o instanceof Chunk.Tile && ((Chunk.Tile) o).obstacle() != null)
+            sg = ((Chunk.Tile) o).obstacle().tileRenderer;
 
         if (!outOfBounds)
         {
@@ -224,18 +225,6 @@ public class StaticTerrainRenderer extends TerrainRenderer
         }
     }
 
-    public void populateTiles()
-    {
-        this.rendererTiles = new RendererTile[Game.currentSizeX][Game.currentSizeY];
-        for (int i = 0; i < Game.currentSizeX; i++)
-        {
-            for (int j = 0; j < Game.currentSizeY; j++)
-            {
-                this.rendererTiles[i][j] = new RendererTile();
-            }
-        }
-    }
-
     public void reset()
     {
         for (RegionRenderer r : this.renderers.values())
@@ -244,8 +233,6 @@ public class StaticTerrainRenderer extends TerrainRenderer
         }
 
         this.outOfBoundsRenderer.renderer.free();
-
-        this.rendererTiles = null;
         this.renderers.clear();
         this.staged = false;
 
@@ -377,15 +364,12 @@ public class StaticTerrainRenderer extends TerrainRenderer
         double s = Obstacle.draw_size;
         Obstacle.draw_size = Game.tile_size;
 
-        this.populateTiles();
+        for (Obstacle o : Game.obstacles)
+            o.postOverride();
 
-        for (int i = 0; i < this.rendererTiles.length; i++)
-        {
-            for (int j = 0; j < this.rendererTiles[i].length; j++)
-            {
+        for (int i = 0; i < Game.currentSizeX; i++)
+            for (int j = 0; j < Game.currentSizeY; j++)
                 this.drawTile(i, j);
-            }
-        }
 
         Obstacle.draw_size = s;
     }

--- a/src/main/java/tanks/rendering/TerrainRenderer.java
+++ b/src/main/java/tanks/rendering/TerrainRenderer.java
@@ -751,14 +751,17 @@ public class TerrainRenderer
         double s = Obstacle.draw_size;
         Obstacle.draw_size = Game.tile_size;
 
+        if (stagedCount == 0)
+            totalObjectsCount = Game.currentSizeX * Game.currentSizeY + Game.obstacles.size();
+
         for (Obstacle o : Game.obstacles)
             o.postOverride();
 
         drawBorders();
 
         long start = System.currentTimeMillis();
-        int x;
-        for (x = stagedCount / Game.currentSizeY; x < Game.currentSizeX && (!allowPartialLoading || System.currentTimeMillis() - start < 50); x++)
+        int x = stagedCount / Game.currentSizeY;
+        for (; x < Game.currentSizeX && (!allowPartialLoading || System.currentTimeMillis() - start < 50); x++)
         {
             for (int y = 0; y < Game.currentSizeY; y++)
                 drawTile(x, y);

--- a/src/main/java/tanks/rendering/TerrainRenderer.java
+++ b/src/main/java/tanks/rendering/TerrainRenderer.java
@@ -1,7 +1,7 @@
 package tanks.rendering;
 
 import basewindow.*;
-import io.netty.util.collection.IntObjectHashMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import tanks.Chunk;
 import tanks.Drawing;
 import tanks.Game;
@@ -15,9 +15,9 @@ public class TerrainRenderer
 {
     public static final int section_size = 2000;
 
-    protected final HashMap<Class<? extends ShaderGroup>, IntObjectHashMap<RegionRenderer>> renderers = new HashMap<>();
+    protected final HashMap<Class<? extends ShaderGroup>, Int2ObjectOpenHashMap<RegionRenderer>> renderers = new HashMap<>();
     protected final HashMap<IBatchRenderableObject, RegionRenderer> renderersByObj = new HashMap<>();
-    protected final IntObjectHashMap<RegionRenderer> outOfBoundsRenderers = new IntObjectHashMap<>();
+    protected final Int2ObjectOpenHashMap<RegionRenderer> outOfBoundsRenderers = new Int2ObjectOpenHashMap<>();
 
     public boolean staged = false;
 
@@ -94,15 +94,15 @@ public class TerrainRenderer
         }
     }
 
-    public IntObjectHashMap<RegionRenderer> getRenderers(Class<? extends ShaderGroup> s)
+    public Int2ObjectOpenHashMap<RegionRenderer> getRenderers(Class<? extends ShaderGroup> s)
     {
-        return renderers.computeIfAbsent(s, k -> new IntObjectHashMap<>());
+        return renderers.computeIfAbsent(s, k -> new Int2ObjectOpenHashMap<>());
     }
 
     public RegionRenderer getRenderer(IBatchRenderableObject o, double x, double y, boolean outOfBounds)
     {
         RegionRenderer s = null;
-        IntObjectHashMap<RegionRenderer> renderers = this.outOfBoundsRenderers;
+        Int2ObjectOpenHashMap<RegionRenderer> renderers = this.outOfBoundsRenderers;
 
         Class<? extends ShaderGroup> sg = ShaderGroup.class;
 
@@ -475,7 +475,7 @@ public class TerrainRenderer
 
     public void reset()
     {
-        for (IntObjectHashMap<RegionRenderer> h : this.renderers.values())
+        for (Int2ObjectOpenHashMap<RegionRenderer> h : this.renderers.values())
             for (RegionRenderer r : h.values())
                 r.renderer.free();
 
@@ -489,7 +489,7 @@ public class TerrainRenderer
         this.stagedCount = 0;
     }
 
-    public void drawMap(IntObjectHashMap<RegionRenderer> renderers, int xOffset, int yOffset)
+    public void drawMap(Int2ObjectOpenHashMap<RegionRenderer> renderers, int xOffset, int yOffset)
     {
         for (RegionRenderer s : renderers.values())
         {

--- a/src/main/java/tanks/rendering/TerrainRenderer.java
+++ b/src/main/java/tanks/rendering/TerrainRenderer.java
@@ -809,8 +809,6 @@ public class TerrainRenderer
             o.draw();
     }
 
-
-
     public static class RegionRenderer
     {
         public BaseShapeBatchRenderer renderer;


### PR DESCRIPTION
- Terrain renderer no longer uses renderer-specific tiles; uses the ones from the tile grid instead
- Minor memory optimizations with renderers