### PR TITLE
Modify TanksON to eat JSONC comments

### DIFF
--- a/src/main/java/tanks/tankson/TanksON.java
+++ b/src/main/java/tanks/tankson/TanksON.java
@@ -42,10 +42,30 @@ public class TanksON
         {
             while (true)
             {
-                if (" \t\n\r".startsWith(this.nextChar() + ""))
+                if (index >= s.length()) {
+                    return; // Reached end of string
+                }
+                char c = this.nextChar();
+                if (Character.isWhitespace(c)) {
                     index++;
-                else
+                } else if (s.startsWith("//", index)) {
+                    // Skip single-line comment
+                    while (index < s.length() && s.charAt(index) != '\n' && s.charAt(index) != '\r') {
+                        index++;
+                    }
+                } else if (s.startsWith("/*", index)) {
+                    // Skip multi-line comment
+                    index += 2; // Skip "/*"
+                    int commentEnd = s.indexOf("*/", index);
+                    if (commentEnd != -1) {
+                        index = commentEnd + 2; // Skip "*/"
+                    } else {
+                        // Malformed comment, treat rest of string as part of comment
+                        index = s.length();
+                    }
+                } else {
                     return;
+                }
             }
         }
     }


### PR DESCRIPTION
This is a quick change to TanksON which makes it eat JSONC style comments. Maybe in the future we will be able to have TanksONC in level files.