### PR TITLE
Fix Arcade Minigame NullPointer Error

### DIFF
--- a/src/main/java/tanks/minigames/Arcade.java
+++ b/src/main/java/tanks/minigames/Arcade.java
@@ -103,7 +103,10 @@ public class Arcade extends Minigame
             for (String si : items)
             {
                 Item.ItemStack<?> i = Item.ItemStack.fromString(null, si);
+
+                String originalName = i.item.name;
                 i.item.name = Translation.translate(i.item.name);
+                itemsMap.put(originalName, i);
 
                 itemNumbers.put(i.item.name, id + 1);
                 id++;


### PR DESCRIPTION
Fixed an issue where the Arcade mini-game caused an error in spawning items when the game language was not English